### PR TITLE
Search Tag API is outdated

### DIFF
--- a/DOC/api/tag.md
+++ b/DOC/api/tag.md
@@ -631,7 +631,8 @@
 ```javascript
 {
 	"name": "akame ga kill",
-	"type": "bangumi"
+	"keywords": true,
+	"multi": true
 }
 ```
 * return:
@@ -639,32 +640,34 @@
 {
   "success": true,
   "found": true,
-  "tag": {
-    "_id": "548f0004f892774b140ac618",
-    "activity": 0,
-    "locale": {
-      "ja": "アカメが斬る!",
-      "zh_cn": "斩·赤红之瞳！",
-      "en": "Akame Ga Kill",
-      "zh_tw": "斬！赤紅之瞳"
-    },
-    "name": "アカメが斬る!",
-    "syn_lowercase": [
-      "アカメが斬る!",
-      "斩·赤红之瞳！",
-      "akame ga kill",
-      "akame ga kiru",
-      "斬！赤紅之瞳"
-    ],
-    "synonyms": [
-      "アカメが斬る!",
-      "斩·赤红之瞳！",
-      "Akame Ga Kill",
-      "Akame Ga Kiru",
-      "斬！赤紅之瞳"
-    ],
-    "type": "bangumi"
-  }
+  "tag": [
+    {
+      "_id": "548f0004f892774b140ac618",
+      "activity": 0,
+      "locale": {
+        "ja": "アカメが斬る!",
+        "zh_cn": "斩·赤红之瞳！",
+        "en": "Akame Ga Kill",
+        "zh_tw": "斬！赤紅之瞳"
+      },
+      "name": "アカメが斬る!",
+      "syn_lowercase": [
+        "アカメが斬る!",
+        "斩·赤红之瞳！",
+        "akame ga kill",
+        "akame ga kiru",
+        "斬！赤紅之瞳"
+      ],
+      "synonyms": [
+        "アカメが斬る!",
+        "斩·赤红之瞳！",
+        "Akame Ga Kill",
+        "Akame Ga Kiru",
+        "斬！赤紅之瞳"
+      ],
+      "type": "bangumi"
+    }
+  ]
 }
 ```
 * note:


### PR DESCRIPTION
from bangumi.moe dump data, I find that /api/tag/search actually make a different request body and response is also different from this API document.
Change:
request body no longer have `type` but added `keywords`, `multi` field. Currently I don't know these two field meaning.
response tag is an array of tags instead of a tag object